### PR TITLE
fix: mark token (bearer token) as isSecret in config_schema

### DIFF
--- a/cmd/baton-kubernetes/config.go
+++ b/cmd/baton-kubernetes/config.go
@@ -43,7 +43,7 @@ var (
 	cacheDirField    = field.StringField(flagCacheDir, field.WithDescription("Default cache directory"))
 	certFileField    = field.StringField(flagCertFile, field.WithDescription("Path to a client certificate file for TLS"), field.WithRequired(false))
 	keyFileField     = field.StringField(flagKeyFile, field.WithDescription("Path to a client key file for TLS"), field.WithRequired(false))
-	bearerTokenField = field.StringField(flagBearerToken, field.WithDescription("Bearer token for authentication to the API server"), field.WithRequired(false))
+	bearerTokenField = field.StringField(flagBearerToken, field.WithDescription("Bearer token for authentication to the API server"), field.WithRequired(false), field.WithIsSecret(true))
 	impersonateField = field.StringField(flagImpersonate,
 		field.WithDescription("Username to impersonate for the operation. User could be a regular user or a service account in a namespace."), field.WithRequired(false))
 	impersonateUIDField = field.StringField(flagImpersonateUID,


### PR DESCRIPTION
BREAKING: adding `isSecret: true` to these fields changes how existing configurations are stored. Customers with existing connector configurations will need to re-enter credentials after this change is deployed.

The credential field(s) are defined in Go via the baton `field` package, which is the source the config schema is derived from (no separate generated config_schema.json is committed in this repo), so adding `field.WithIsSecret(true)` to the field definition is the complete fix.

<!-- stargate: connector-secret-audit-phase11 -->