### PR TITLE
docs: document connection resolution, system: subject exclusion, and the full flag reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # `baton-kubernetes` [![Go Reference](https://pkg.go.dev/badge/github.com/conductorone/baton-kubernetes.svg)](https://pkg.go.dev/github.com/conductorone/baton-kubernetes) ![main ci](https://github.com/conductorone/baton-kubernetes/actions/workflows/main.yaml/badge.svg)
 
-`baton-kubernetes` is a connector for built using the [Baton SDK](https://github.com/conductorone/baton-sdk).
+`baton-kubernetes` is a connector for Kubernetes built using the [Baton SDK](https://github.com/conductorone/baton-sdk). It syncs identity and access data from a cluster's RBAC objects.
 
 Check out [Baton](https://github.com/conductorone/baton) to learn more the project in general.
 
@@ -86,6 +86,49 @@ everyone. If you have questions, problems, or ideas: Please open a GitHub Issue!
 
 See [CONTRIBUTING.md](https://github.com/ConductorOne/baton/blob/main/CONTRIBUTING.md) for more details.
 
+# Connector configuration
+
+These flags configure the cluster connection. Every flag also accepts an environment variable, formed by uppercasing the flag name, replacing dashes with underscores and prefixing `BATON_` — `--kubeconfig` becomes `BATON_KUBECONFIG`. The generic Baton flags (`--client-id`, `--client-secret`, `-f/--file`, `--log-level`, and the rest) are listed in the full usage output below.
+
+## Choosing a cluster
+
+| Flag | Description | Default |
+| --- | --- | --- |
+| `--kubeconfig` | Path to the kubeconfig file. The file must exist; the connector exits with `specified kubeconfig file does not exist: <path>` if it does not. | |
+| `--server` | Address and port of the Kubernetes API server, for example `https://api.example.com:6443`. | |
+| `--context` | Name of the kubeconfig context to use. | the kubeconfig's current context |
+| `--cluster` | Name of the kubeconfig cluster to use. | |
+| `--user` | Name of the kubeconfig user to use. | |
+
+When you pass neither `--kubeconfig` nor `--server`, the connector resolves the cluster from the environment: the `KUBECONFIG` variable (a `:`-separated list of paths, first existing file wins), then `$HOME/.kube/config`, then an in-cluster service account. If none of the three is present it exits with `no kubeconfig available: <path> does not exist and no in-cluster service account found`. Name the target explicitly with `--kubeconfig` or `--server` when you run the connector outside a cluster — otherwise it follows whatever cluster your current context points at.
+
+## Authenticating
+
+Pick one method. `--token`, `--client-certificate`/`--client-key` and `--as` are mutually exclusive: combining them exits with `if any flags in the group [token client-certificate] are set none of the others can be`. `--client-certificate` and `--client-key` are required together.
+
+| Flag | Description |
+| --- | --- |
+| `--token` | Bearer token for authentication to the API server. Marked secret. |
+| `--client-certificate` | Path to a client certificate file for TLS. Requires `--client-key`. |
+| `--client-key` | Path to a client key file for TLS. Requires `--client-certificate`. |
+| `--as` | Username to impersonate. May be a user or a service account. |
+| `--as-uid` | UID to impersonate. |
+| `--as-group` | Group to impersonate. Repeat the flag for multiple groups. Kubernetes rejects a group without `--as`. |
+
+## TLS and transport
+
+| Flag | Description | Default |
+| --- | --- | --- |
+| `--certificate-authority` | Path to a CA certificate file used to verify the API server. Without it, a self-signed cluster certificate fails with `x509: certificate signed by unknown authority`. | |
+| `--tls-server-name` | Server name for certificate validation. Falls back to the hostname in the server URL. | |
+| `--insecure-skip-tls-verify` | Skip verification of the server's certificate. | `false` |
+| `--request-timeout` | Time to wait for a single server request, for example `30s` or `2m`. `0` means no timeout. | `0` |
+| `--disable-compression` | Opt out of response compression for all requests. | `false` |
+
+## Selecting resource types
+
+The connector syncs the six core RBAC types by default. Use the standard `--sync-resource-types` flag (or `BATON_SYNC_RESOURCE_TYPES`) to select a different set, as described in [Data Model](#data-model). An explicit selection replaces the default set rather than adding to it.
+
 # `baton-kubernetes` Command Line Usage
 
 ```
@@ -98,18 +141,54 @@ Usage:
 Available Commands:
   capabilities       Get connector capabilities
   completion         Generate the autocompletion script for the specified shell
+  config             Get the connector config schema
+  health-check       Check the health of a running connector
   help               Help about any command
 
 Flags:
-      --client-id string             The client ID used to authenticate with ConductorOne ($BATON_CLIENT_ID)
-      --client-secret string         The client secret used to authenticate with ConductorOne ($BATON_CLIENT_SECRET)
-  -f, --file string                  The path to the c1z file to sync with ($BATON_FILE) (default "sync.c1z")
-  -h, --help                         help for baton-kubernetes
-      --log-format string            The output format for logs: json, console ($BATON_LOG_FORMAT) (default "json")
-      --log-level string             The log level: debug, info, warn, error ($BATON_LOG_LEVEL) (default "info")
-  -p, --provisioning                 If this connector supports provisioning, this must be set in order for provisioning actions to be enabled ($BATON_PROVISIONING)
-      --ticketing                    This must be set to enable ticketing support ($BATON_TICKETING)
-  -v, --version                      version for baton-kubernetes
+      --as string                                        Username to impersonate for the operation. User could be a regular user or a service account in a namespace. ($BATON_AS)
+      --as-group strings                                 Group to impersonate for the operation, this flag can be repeated to specify multiple groups. ($BATON_AS_GROUP)
+      --as-uid string                                    UID to impersonate for the operation. ($BATON_AS_UID)
+      --auth-method string                               ($BATON_AUTH_METHOD)
+      --certificate-authority string                     Path to a cert file for the certificate authority ($BATON_CERTIFICATE_AUTHORITY)
+      --client-certificate string                        Path to a client certificate file for TLS ($BATON_CLIENT_CERTIFICATE)
+      --client-id string                                 The client ID used to authenticate with ConductorOne ($BATON_CLIENT_ID)
+      --client-key string                                Path to a client key file for TLS ($BATON_CLIENT_KEY)
+      --client-secret string                             The client secret used to authenticate with ConductorOne ($BATON_CLIENT_SECRET)
+      --cluster string                                   The name of the kubeconfig cluster to use ($BATON_CLUSTER)
+      --context string                                   The name of the kubeconfig context to use ($BATON_CONTEXT)
+      --disable-compression                              If true, opt-out of response compression for all requests to the server ($BATON_DISABLE_COMPRESSION)
+      --external-resource-c1z string                     The path to the c1z file to sync external baton resources with ($BATON_EXTERNAL_RESOURCE_C1Z)
+      --external-resource-entitlement-id-filter string   The entitlement that external users, groups must have access to sync external baton resources ($BATON_EXTERNAL_RESOURCE_ENTITLEMENT_ID_FILTER)
+  -f, --file string                                      The path to the c1z file to sync with ($BATON_FILE) (default "sync.c1z")
+      --health-check                                     Enable the HTTP health check endpoint ($BATON_HEALTH_CHECK)
+      --health-check-port int                            Port for the HTTP health check endpoint ($BATON_HEALTH_CHECK_PORT) (default 8081)
+  -h, --help                                             help for baton-kubernetes
+      --http-timeout-seconds int                         HTTP client timeout in seconds (max 1800) ($BATON_HTTP_TIMEOUT_SECONDS) (default 300)
+      --insecure-skip-tls-verify                         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure ($BATON_INSECURE_SKIP_TLS_VERIFY)
+      --keep-previous-sync-c1z                           Keep the previously synced c1z on disk to enable ETag replay across service-mode syncs (requires a connector that supports ETag replay; costs one c1z of local disk) ($BATON_KEEP_PREVIOUS_SYNC_C1Z)
+      --kubeconfig string                                Path to the kubeconfig file to use for CLI requests. ($BATON_KUBECONFIG)
+      --log-format string                                The output format for logs: json, console ($BATON_LOG_FORMAT) (default "json")
+      --log-level string                                 The log level: debug, info, warn, error ($BATON_LOG_LEVEL) (default "info")
+      --log-level-debug-expires-at string                The timestamp indicating when debug-level logging should expire ($BATON_LOG_LEVEL_DEBUG_EXPIRES_AT)
+      --log-path strings                                 The file path to write logs to ($BATON_LOG_PATH)
+      --otel-collector-endpoint string                   The endpoint of the OpenTelemetry collector to send observability data to (used for both tracing and logging if specific endpoints are not provided) ($BATON_OTEL_COLLECTOR_ENDPOINT)
+      --parallel-sync                                    Deprecated: use --workers instead. ($BATON_PARALLEL_SYNC)
+  -p, --provisioning                                     This must be set in order for provisioning actions to be enabled ($BATON_PROVISIONING)
+      --request-timeout string                           The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. ($BATON_REQUEST_TIMEOUT) (default "0")
+      --server string                                    The address and port of the Kubernetes API server ($BATON_SERVER)
+      --skip-entitlements-and-grants                     This must be set to skip syncing of entitlements and grants ($BATON_SKIP_ENTITLEMENTS_AND_GRANTS)
+      --skip-full-sync                                   This must be set to skip a full sync ($BATON_SKIP_FULL_SYNC)
+      --storage-engine string                            The storage engine to use when opening the sync c1z file: sqlite or pebble. Leave unset to use the baton-sdk default. ($BATON_STORAGE_ENGINE)
+      --sync-resource-types strings                      The resource type IDs to sync ($BATON_SYNC_RESOURCE_TYPES)
+      --sync-resources strings                           The resource IDs to sync ($BATON_SYNC_RESOURCES)
+      --task-concurrency int                             The number of Baton tasks to run concurrently in service mode. Tasks may include sync, grant, revoke, and more. Minimum value is 1, maximum value is 100. ($BATON_TASK_CONCURRENCY) (default 3)
+      --ticketing                                        This must be set to enable ticketing support ($BATON_TICKETING)
+      --tls-server-name string                           Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used ($BATON_TLS_SERVER_NAME)
+      --token string                                     Bearer token for authentication to the API server ($BATON_TOKEN)
+      --user string                                      The name of the kubeconfig user to use ($BATON_USER)
+  -v, --version                                          version for baton-kubernetes
+      --workers int                                      The number of sync workers to use. -1 for auto-detect, 0 for sequential, >0 for parallel ($BATON_WORKERS)
 
 Use "baton-kubernetes [command] --help" for more information about a command.
 ```

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -36,6 +36,9 @@ baton-kubernetes --sync-resource-types namespace,service_account,role,cluster_ro
 ```
 </Note>
 
+**Notes:**
+- Bindings whose subject sits in the `system:` namespace are excluded from grants. This covers groups such as `system:masters` and `system:serviceaccounts:<namespace>`, and users such as `system:kube-controller-manager` — subjects that belong to Kubernetes' own control plane. Roles and cluster roles named `system:*` are still synced; the exclusion applies to the subject side of a binding. If your cluster binds a `system:` group to real users, that binding produces no grant in C1.
+
 ## Understanding Kubernetes identity
 
 Kubernetes does not have a built-in user store. Identity is determined at authentication time by the method used to connect to the API server:
@@ -64,6 +67,23 @@ The following authentication methods are **not supported** for group membership 
 | In-cluster service account tokens | Group is always `system:serviceaccounts:<namespace>`, inferred from the token's namespace |
 
 **What this means for access reviews:** RBAC bindings to groups are fully visible. If `ClusterRole:admin` is bound to group `developers`, that grant is synced. However, the list of users in `developers` is only complete if those users authenticate via x509 client certificates whose kubeconfigs are stored as Secrets in the cluster. Users authenticating via OIDC or webhook will appear as grant targets on Roles and ClusterRoles if they have direct bindings, but not as members of their groups.
+
+## Understanding how the connector selects a cluster
+
+The connector resolves its target cluster in this order:
+
+1. **`--kubeconfig`** — the connector reads this file. The path must exist, or the connector exits with `specified kubeconfig file does not exist: <path>`.
+2. **`--server`** — with no `--kubeconfig`, the connector connects to this URL directly. Supply credentials separately with `--token`, or with `--client-certificate` and `--client-key`, or rely on an in-cluster service account.
+3. **The environment** — with neither flag set, the connector requires one of the following to be present, and the standard Kubernetes client loading rules then decide which one applies:
+   - the `KUBECONFIG` environment variable, a `:`-separated list of paths whose first existing file wins
+   - the default kubeconfig at `$HOME/.kube/config`
+   - an in-cluster service account token, mounted at `/var/run/secrets/kubernetes.io/serviceaccount/token`
+
+   When none of the three exists, the connector exits with `no kubeconfig available: <path> does not exist and no in-cluster service account found`.
+
+<Warning>
+Name the target cluster explicitly when you run the connector outside a cluster. With neither `--kubeconfig` nor `--server` set, the connector follows the current context of your default kubeconfig, which may point at a different cluster than the one you intend to sync. Confirm the context with `kubectl config current-context` before the first sync.
+</Warning>
 
 ## Before you begin
 

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -37,7 +37,7 @@ baton-kubernetes --sync-resource-types namespace,service_account,role,cluster_ro
 </Note>
 
 **Notes:**
-- Bindings whose subject sits in the `system:` namespace are excluded from grants. This covers groups such as `system:masters` and `system:serviceaccounts:<namespace>`, and users such as `system:kube-controller-manager` — subjects that belong to Kubernetes' own control plane. Roles and cluster roles named `system:*` are still synced; the exclusion applies to the subject side of a binding. If your cluster binds a `system:` group to real users, that binding produces no grant in C1.
+- Bindings whose subject name contains `system:` are excluded from grants. This covers groups such as `system:masters` and `system:serviceaccounts:<namespace>`, and users such as `system:kube-controller-manager` — subjects that belong to Kubernetes' own control plane. Roles and cluster roles named `system:*` are still synced; the exclusion applies to the subject side of a binding. If your cluster binds a `system:` group to real users, that binding produces no grant in C1.
 
 ## Understanding Kubernetes identity
 

--- a/docs/docs-info.md
+++ b/docs/docs-info.md
@@ -18,7 +18,7 @@ While developing the connector, please fill out this form. This information is n
     Two behaviours worth documenting, because neither is obvious from the resource list:
 
     - **Users and groups are derived, not enumerated.** Kubernetes has no user store. The connector materialises a principal only when an RBAC binding references it, or when it appears as the `CN` of an x509 client certificate inside a kubeconfig Secret. A user with no binding is invisible by design.
-    - **Bindings whose subject sits in the `system:` namespace produce no grants.** Roles and cluster roles named `system:*` are still synced; the exclusion applies to the subject side of a binding. If a cluster binds a `system:` group to real users, that binding does not appear as access in C1.
+    - **Bindings whose subject name contains `system:` produce no grants.** Roles and cluster roles named `system:*` are still synced; the exclusion applies to the subject side of a binding. If a cluster binds a `system:` group to real users, that binding does not appear as access in C1.
 
 2. Can the connector provision any resources? If so, which ones?
 

--- a/docs/docs-info.md
+++ b/docs/docs-info.md
@@ -1,0 +1,76 @@
+While developing the connector, please fill out this form. This information is needed to write docs and to help other users set up the connector.
+
+## Connector capabilities
+
+1. What resources does the connector sync?
+
+    Six resource types sync by default:
+
+    - Namespaces
+    - Service accounts
+    - Kubernetes users (`kube_user`)
+    - Kubernetes groups (`kube_group`)
+    - Roles
+    - Cluster roles
+
+    Seven more are declared but excluded from the default sync, and are selectable with the standard `--sync-resource-types` flag: Nodes, Pods, Deployments, StatefulSets, DaemonSets, Secrets, ConfigMaps. They carry `OptInRequired` annotations in `baton_capabilities.json`. They expose verb entitlements (`get`, `list`, `watch`, `create`, `update`, `patch`, `delete`, and for pods also `exec` and `portforward`) that never receive grants, which is why they are opt-in rather than default.
+
+    Two behaviours worth documenting, because neither is obvious from the resource list:
+
+    - **Users and groups are derived, not enumerated.** Kubernetes has no user store. The connector materialises a principal only when an RBAC binding references it, or when it appears as the `CN` of an x509 client certificate inside a kubeconfig Secret. A user with no binding is invisible by design.
+    - **Bindings whose subject sits in the `system:` namespace produce no grants.** Roles and cluster roles named `system:*` are still synced; the exclusion applies to the subject side of a binding. If a cluster binds a `system:` group to real users, that binding does not appear as access in C1.
+
+2. Can the connector provision any resources? If so, which ones?
+
+    No. `baton_capabilities.json` declares `CAPABILITY_SYNC` only, and there is no `Provisioner()` implementation, no `Grant`/`Revoke`, and no account create or delete anywhere in `pkg/connector`. The connector is read-only.
+
+## Connector credentials
+
+1. What credentials or information are needed to set up the connector? (For example, API key, client ID and secret, domain, etc.)
+
+    One of three ways to reach the cluster:
+
+    - **A kubeconfig file** (`--kubeconfig`) — the usual choice when running the connector outside the cluster.
+    - **A bearer token plus the API server URL** (`--token`, `--server`, and `--certificate-authority` for the cluster CA) — the choice when the API server is reachable directly.
+    - **A client certificate and key plus the API server URL** (`--client-certificate`, `--client-key`, `--server`, `--certificate-authority`).
+
+    Deployed inside the cluster, the connector uses the mounted service account token and needs no credential flags at all.
+
+    Impersonation (`--as`, `--as-uid`, `--as-group`) is available as an alternative to a direct credential. All three methods are mutually exclusive with each other; the certificate and key are required together.
+
+2. For each item in the list above:
+
+   * How does a user create or look up that credential or info? Please include links to (non-gated) documentation, screenshots (of the UI or of gated docs), or a video of the process.
+
+     * **Service account and RBAC permissions**: apply the manifest in `docs/connector.mdx` ("Set up RBAC permissions in your cluster"), which creates the namespace, the service account, and a read-only ClusterRole and ClusterRoleBinding. See [Using RBAC Authorization](https://kubernetes.io/docs/reference/access-authn-authz/rbac/).
+     * **Bearer token**: create a long-lived token by applying a `kubernetes.io/service-account-token` Secret that references the service account, then read the token from that Secret. See [Manually create a long-lived API token for a ServiceAccount](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#manually-create-an-api-token-for-a-serviceaccount).
+     * **API server URL**: `kubectl cluster-info`, or the `server` field of the current context in the kubeconfig.
+     * **Cluster CA certificate**: the `certificate-authority-data` field of the cluster entry in the kubeconfig, base64-decoded to a file.
+     * **Client certificate**: issue one through the CertificateSigningRequest API with the `kubernetes.io/kube-apiserver-client` signer. See [Certificate Signing Requests](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/).
+
+   * Does the credential need any specific scopes or permissions? If so, list them here.
+
+     Cluster-wide `get`, `list` and `watch` on:
+
+     - `namespaces`, `serviceaccounts` (core API group)
+     - `roles`, `clusterroles`, `rolebindings`, `clusterrolebindings` (`rbac.authorization.k8s.io`)
+     - `secrets` (core API group) — **optional**, see below
+     - `pods`, `nodes`, `configmaps` (core) and `deployments`, `statefulsets`, `daemonsets` (`apps`) — only when those opt-in types are selected
+
+     `secrets` read is genuinely optional and its absence degrades cleanly rather than failing the sync. Without it, the connector logs `skipping cert-based user discovery: not permitted to list secrets` and completes: every RBAC-derived principal still syncs, and only the x509 group-membership layer is lost. Verified on v0.1.0 against a cluster where the connector's service account was denied `secrets` — the sync finished with zero errors and produced no group membership grants, while the user and group counts were otherwise unchanged.
+
+    * If applicable: Is the list of scopes or permissions different to sync (read) versus provision (read-write)? If so, list the difference here.
+
+      Not applicable. The connector is read-only, so read permissions are the whole surface.
+
+     * What level of access or permissions does the user need in order to create the credentials? (For example, must be a super administrator, must have access to the admin console, etc.)
+
+     Permission to create namespaces, service accounts, ClusterRoles and ClusterRoleBindings in the target cluster — in practice `cluster-admin` or an equivalent role. Issuing a client certificate additionally requires permission to create and approve CertificateSigningRequests.
+
+## Limitations to document
+
+- **Group membership is only discoverable for x509 client certificates stored in kubeconfig Secrets.** Kubernetes never persists group claims: they exist only inside the credential presented at authentication time. The connector parses the `O=` fields of a client certificate embedded in a kubeconfig Secret and emits membership from them. Membership for users authenticating via OIDC, webhook authenticators, bootstrap tokens, or in-cluster service account tokens cannot be resolved. Those users still appear as grant targets on roles and cluster roles when they hold a direct binding.
+- **Grants to group subjects are not expanded.** Vanilla Kubernetes has no membership source to expand through, so a role granted to a group is recorded against the group and not propagated to its members. The cloud variants of this connector add their own expansion.
+- **An explicit `--sync-resource-types` selection replaces the default set** rather than adding to it, so a selection must list every type the deployment wants.
+
+This form was compiled from an end-to-end validation of v0.1.0 rather than by the connector author, so the sections above describe measured behaviour. Anything a docs writer needs that is not here is missing rather than intentionally omitted.


### PR DESCRIPTION
## Summary

Four documentation gaps found while validating the v0.1.0 release end-to-end against a live cluster, plus one behaviour the page never mentioned. Docs-only — no code changes.

## What changed and why

**README: the intro named no target system.** `` `baton-kubernetes` is a connector for built using the Baton SDK `` — the template placeholder was never filled in. *(verified)*

**README: the usage block predated the `pkg/config` migration.** It listed only `--client-id`, `--client-secret`, `-f/--file`, `--log-format`, `--log-level`, `-p/--provisioning`, `--ticketing`, `-h`, `-v` — none of the connector's own flags. It is now regenerated from the real `--help` output and is byte-identical to it. Above it, a new **Connector configuration** section groups the connector's flags by purpose and states the constraints `--help` cannot express: `--token`, `--client-certificate`/`--client-key` and `--as` are mutually exclusive, and the certificate and key are required together. *(verified against `pkg/config/config.go`; the constraint errors were exercised live)*

**docs page: nothing described how the connector picks a cluster.** With neither `--kubeconfig` nor `--server` set, it resolves against the ambient `KUBECONFIG` / `$HOME/.kube/config` / in-cluster service account (`pkg/connector/connector.go:107`, guard at `:118-145`). Searching the page for the ambient kubeconfig, the current context or `KUBECONFIG` returned nothing. The new section gives the resolution order and quotes both failure messages verbatim, so a reader who hits one can find the page by searching the error. *(verified)*

**docs page: bindings to `system:` subjects produce no grants.** `pkg/connector/helper.go:137` drops any subject whose name contains `system:`. Measured on a seeded cluster: 0 of 1653 grant principals were `system:*`, while the cluster genuinely bound `system:masters` and two seeded `system:` subjects, and the kind image's own bindings reference `system:kube-controller-manager` and `system:kube-scheduler`. Roles and cluster roles named `system:*` are still synced — it is the subject side that is filtered — so the page now says which side and what the audit consequence is. *(measured)*

**`docs/docs-info.md` did not exist.** The internal form is added, following the structure used by other connectors, covering the resource surface, the read-only capability, the three credential paths, the cluster-wide RBAC permissions required, and the fact that `secrets` read is optional — without it the sync completes and only x509 group membership is lost. Compiled from validation rather than by the connector author, which the file states.

## Worth a reviewer's eye

- The `<Warning>` in the new section suggests `kubectl config current-context`. `build-connector-docs.md`'s Quality Checklist bans `kubectl` commands on the page; I read that rule as targeting *verification* steps that should describe UI behaviour instead, so the command is inline in prose rather than a shell block. Happy to drop it if you read the rule more strictly.
- The capabilities table is hand-maintained and no generator is wired for it (`connector-docs-verify.yaml` runs `mdx-lint` only), so no `AUTO-GENERATED` markers were added — they would advertise a regeneration that does not happen.
- `helper.go:137` uses `strings.Contains`, so a subject such as `acme:system:admins` is also dropped. The page documents the intent rather than the substring behaviour; if that match is unintentional it is a code change, not a docs one.

`mdx-lint` was run locally against the edited page with the pinned CI dependencies and passes.